### PR TITLE
Add official documentation references to tutorials

### DIFF
--- a/01-index.md
+++ b/01-index.md
@@ -2,6 +2,9 @@
 How To Clear
 ============
 
+For official documentation on these topics please see
+[https://clearlinux.org/documentation](clearlinux.org/documentation).
+
 ## Table of Contents
 
  1.  [Index](01-index.md)

--- a/02-concepts.md
+++ b/02-concepts.md
@@ -2,6 +2,9 @@
 How To Clear - Clear Linux distribution concepts
 ================================================
 
+For official documentation on these topics please see
+[https://clearlinux.org/documentation](clearlinux.org/documentation).
+
 ## What this document explains
 
 In the training, we will use the Clear Linux OS Team vocabulary to

--- a/03-scope.md
+++ b/03-scope.md
@@ -2,6 +2,9 @@
 How To Clear - Scope of this training
 =====================================
 
+For official documentation on these topics please see
+[https://clearlinux.org/documentation](clearlinux.org/documentation).
+
 ## Aim and scope of this training
 
 The goal of this training is to cover most of the technology used to

--- a/04-mixing.md
+++ b/04-mixing.md
@@ -2,6 +2,10 @@
 How To Clear - Mixing content and creating updates
 ==================================================
 
+For official documentation on these topics please see
+[https://clearlinux.org/documentation/clear-linux/guides/maintenance/mixer](mixer
+documentation).
+
 ## What you'll learn in this chapter
 
 * Initializing a new content stream

--- a/05-deploying.md
+++ b/05-deploying.md
@@ -2,6 +2,9 @@
 How To Clear - Deploying updates to a target
 ============================================
 
+For official documentation on these topics please see
+[https://clearlinux.org/documentation](clearlinux.org/documentation).
+
 ## What you'll learn in this chapter
 
 * Creating an update content server

--- a/06-rpms.md
+++ b/06-rpms.md
@@ -2,6 +2,9 @@
 How To Clear - Creating and mixing custom RPMs
 ==============================================
 
+For official documentation on these topics please see
+[https://clearlinux.org/documentation](clearlinux.org/documentation).
+
 ## What you'll learn in this chapter
 
 * Modifying a Clear Linux OS kernel RPM

--- a/07-1-telemetry.md
+++ b/07-1-telemetry.md
@@ -2,6 +2,9 @@
 How To Clear - Clear Linux OS telemetry
 =======================================
 
+For official documentation on these topics please see
+[https://clearlinux.org/documentation](clearlinux.org/documentation).
+
 ## What you'll learn in this chapter
 
 * Ground rules of telemetry, privacy, opt-in

--- a/07-2-qa-testing.md
+++ b/07-2-qa-testing.md
@@ -2,6 +2,9 @@
 How To Clear - QA and testing Clear update content
 ==================================================
 
+For official documentation on these topics please see
+[https://clearlinux.org/documentation](clearlinux.org/documentation).
+
 ## What you'll learn in this chapter
 
 * Build time tests concepts

--- a/07-3-debugging.md
+++ b/07-3-debugging.md
@@ -2,6 +2,9 @@
 How To Clear - Debugging applications in Clear Linux OS
 =======================================================
 
+For official documentation on these topics please see
+[https://clearlinux.org/documentation](clearlinux.org/documentation).
+
 ## What you'll learn in this chapter
 
 * Special debug file system concepts for Clear Linux OS

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 How to Clear
 ============
 
+For official documentation on these topics please see
+[https://clearlinux.org/documentation](clearlinux.org/documentation).
+
 ## What is this?
 
 This project contains documents that describe how to create a Clear


### PR DESCRIPTION
Many users are stumbling on this repository from a google search and
expecting it to

1) be a complete usage documentation on how to develop a Clear Linux
   derivative and
2) that the methods described in this documentation are exhaustive and
   up-to-date.

Add references to direct users to the officially maintained and
centrally managed documentation we expect them to use for most use
cases.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>